### PR TITLE
Editorial changes

### DIFF
--- a/report.html
+++ b/report.html
@@ -51,22 +51,23 @@
 
 <p>During the W3C Workshop discussion, we did the following:</p>
 <ul>
-    <li>Identified stakeholders of Smart Cities standardization to drive the development of Web standards aligned with the real needs of Smart Cities</li>
-    <li>Clarified reasonable applications for Smart Cities technologies we agree to build</li>
-    <li>and saw how to improve the draft Charter for the potential Smart Cities Interest Group for further discussions within that IG</li>
+    <li>Identified Smart Cities standardization stakeholders to drive the development of Web standards aligned with the real needs of Smart Cities</li>
+    <li>Clarified reasonable applications for Smart Cities technologies</li>
+    <li>Saw how to improve the draft Charter for the potential Smart Cities Interest Group for further discussions within that IG</li>
 </ul>
 
 <p>We also confirmed that it would be very important to consider
     inclusive design including accessibility, privacy, security, and
-    internationalization, because Smart Cities' applications are tightly
-    related to the people who live in cities, and potentially would have
-    negative impacts on their lives.</p>
+    internationalization. Smart City applications are tightly
+    related to the people who live in cities.  We want Smart City
+    technology to have a positive impact on their lives and want to avoid
+    unintended negative consequences.</p>
 
 <p>Following the workshop, as a concrete next step, the W3C will finalize
     the <a href="http://w3c.github.io/wot/charters/smart-cities/smart-cities-ig-charter.html">
     draft Charter for a potential Smart Cities Interest Group</a>
     and launch the group to start further discussion on the use cases
-    and requirements for Smart Cities as well as survey of existing
+    and requirements for Smart Cities as well as survey existing
     technologies and standards for Smart Cities.
 
     Note that we will closely liaise with
@@ -76,9 +77,11 @@
 
 <h2 id="sessions">Workshop Sessions</h2>
 <p>The workshop consisted of three separate sessions due to
-        participation from various locations, and the format worked very
+        participation from various locations.  The format worked very
         well to let all the speakers and other attendees to participate
-        in the workshop discussion regardless of their timezones.</p>
+        in the workshop discussion regardless of their timezones.
+        All sessions were recorded.
+</p>
 
 <p>Each of the three sessions had the following sub-sessions:</p>
 <ul>
@@ -95,7 +98,7 @@ important requirements for the draft Smart Cities IG Charter.
 And then at the end of each session, we summarized what we discussed
 during the workshop.
 In addition, at the end of the final third session, we confirmed a
-dedicated discussion group is needed for further discussion and what to
+dedicated discussion group is needed for further discussion and what needs to
     be added to the <a href="http://w3c.github.io/wot/charters/smart-cities/smart-cities-ig-charter.html">draft Smart Cities IG Charter</a></p>
 
 <p>The summary of each session is available below. Please see also the detailed <a href="https://www.w3.org/2021/06/25-smart-cities-minutes.html">minutes from the workshop</a>.</p>
@@ -112,24 +115,24 @@ dedicated discussion group is needed for further discussion and what to
 <ul>
     <li><a href="talks.html#qian">Heng QIAN: The Uniqueness of Smart City ICT</a></li>
     <li><a href="talks.html#lee">Peter Lee: Smarter Suffolk</a></li>
-    <li>Discussion & developing a list of the most important requirements for the Smart Cities use cases</li>
+    <li>Discussion and development of a list of the most important requirements for the Smart Cities use cases</li>
 </ul>
 
 <h4 id="session1-3">3. Needs and possible solutions for Web-based Smart Cities</h4>
 <ul>
     <li><a href="talks.html#kaebisch">Sebastian Kaebisch: Standardized Service Orchestration in Smart City</a></li>
-    <li>Discussion & developing a list of the most important requirements for Web-based Smart Cities</li>
+    <li>Discussion and development of a list of the most important requirements for Web-based Smart Cities</li>
 </ul>
 
 <h4 id="session1-4">4. Cross-cutting issues for Smart Cities</h4>
 <ul>
     <li><a href="talks.html#chala">Sisay Chala, Otilia Werner-Kytölä: Privacy-Aware Information Base in the Context of Smart Cities</a></li>
-    <li>Discussion & developing a list of the most important requirements for Cross-cutting issues for Smart Cities</li>
+    <li>Discussion and development of a list of the most important requirements for Cross-cutting issues for Smart Cities</li>
 </ul>
 
 <h4 id="session1-5">5. Wrap-up</h4>
 <ul>
-    <li>We summarized what were the missing requirements to be added to the proposed IG Charter.</li>
+    <li>We summarized some missing requirements that should be added to the proposed IG Charter.</li>
 </ul>
 </section>
 
@@ -144,13 +147,13 @@ dedicated discussion group is needed for further discussion and what to
 <ul>
     <li><a href="talks.html#lieberman">Josh Lieberman: Socializing Urban Digital Twins</a></li>
     <li><a href="talks.html#shiohama">Daihei Shiohama: Publishing WoT use case for Japan Smart Cities</a></li>
-    <li>Discussion & developing a list of the most important requirements for the Smart Cities use cases</li>
+    <li>Discussion and development of a list of the most important requirements for the Smart Cities use cases</li>
 </ul>
 
 <h4 id="session2-3">3. Summary of the current status of Smart Cities - Existing standards</h4>
 <ul>
     <li><a href="talks.html#blum">Jerome Blum: ECLASS as a standardized Taxonomy, Terminology and Semantic for Smart Cities</a></li>
-    <li>Discussion & developing a list of the most important requirements for the Smart Cities standards</li>
+    <li>Discussion and development of a list of the most important requirements for the Smart Cities standards</li>
 </ul>
 
 <h4 id="session2-4">4. Needs and possible solutions for Web-based Smart Cities</h4>
@@ -159,18 +162,18 @@ dedicated discussion group is needed for further discussion and what to
     <li><a href="talks.html#cimmino">Andrea Cimmino: Shifting from smart cities to smart communities using Web technologies</a></li>
     <li><a href="talks.html#lu">Jacqueline Lu: Transparency Interfaces for Everyday Places</a></li>
     <li><a href="talks.html#mccomb">Dave McComb: Lessons Learned from Enterprise Ontologies to Smart Cities</a></li>
-    <li>Discussion & developing a list of the most important requirements for Web-based Smart Cities</li>
+    <li>Discussion and development of a list of the most important requirements for Web-based Smart Cities</li>
 </ul>
 
 <h4 id="session2-5">5. Cross-cutting issues for Smart Cities</h4>
 <ul>
     <li><a href="talks.html#dahl">Deborah Dahl: Intelligent User Interfaces to Smart Cities</a></li>
-    <li>Discussion & developing a list of the most important requirements for Cross-cutting issues for Smart Cities</li>
+    <li>Discussion and development of a list of the most important requirements for Cross-cutting issues for Smart Cities</li>
 </ul>
 
 <h4 id="session2-6">6. Wrap-up</h4>
 <ul>
-    <li>We summarized what were the missing requirements to be added to the proposed IG Charter.</li>
+    <li>We summarized some missing requirements that should be added to the proposed IG Charter.</li>
 </ul>
 </section>
 
@@ -184,26 +187,26 @@ dedicated discussion group is needed for further discussion and what to
 <h4 id="session3-2">2. Summary of the current status of Smart Cities - Existing standards</h4>
 <ul>
     <li><a href="talks.html#loureiro">Clarissa Loureiro: Smart City Maturity Model for Developing Countries Scenarios</a></li>
-    <li>Discussion & developing a list of the most important requirements for the Smart Cities standards</li>
+    <li>Discussion and development of a list of the most important requirements for the Smart Cities standards</li>
 </ul>
 
 <h4 id="session3-3">3. Cross-cutting issues for Smart Cities</h4>
 <ul>
     <li><a href="talks.html#cheng">Baoping CHENG: Multimedia communication technology reshapes smart home life</a></li>
     <li><a href="talks.html#ashimura">Kaz Ashimura: Data Governance for Smart Cities</a></li>
-    <li>Discussion & developing a list of the most important requirements for Cross-cutting issues for Smart Cities</li>
+    <li>Discussion and development of a list of the most important requirements for Cross-cutting issues for Smart Cities</li>
 </ul>
 
 <h4 id="session3-4">4. Wrap-up</h4>
 <ul>
-    <li>We summarized what were the missing requirements to be added to the proposed IG Charter.</li>
+    <li>We summarized some missing requirements that should be added to the proposed IG Charter.</li>
 </ul>
 
 <h4 id="session3-5">5. Next steps</h4>
 <ul>
-    <li>We've identified topics and important viewpoints for the Scope section of the <a href="http://w3c.github.io/wot/charters/smart-cities/smart-cities-ig-charter.html">draft Smart Cities Interest Group Charter</a>, e.g., data governance, smart cities in developing countries, survey of existing smart cities.</li>
-    <li>We also identified important additional SDOs, Government agencies, Smart City projects and communities to liaise with and potential liaison contacts from those organizations as the workshop speakers, e.g., Josh Lieberman (OGC), Heng Qian (ISO/IEC JTC1), Peter Lee (BSI), Jerome Blum (ECLASS), Sisay Chala (GOEASY), Jacqueline Lu (DTPR), Dave McComb (semantic arts), Clarissa Loureiro (Clarissa Loureiro)</li>
-    <li>We will finalize the <a href="http://w3c.github.io/wot/charters/smart-cities/smart-cities-ig-charter.html">draft Smart Cities Interest Group Charter</a> based on the feedback from the workshop, and launch the group to start further discussion on the use cases and requirements for Smart Cities as well as survey of existing technologies and standards for Smart Cities.</li>
+    <li>We've identified topics and important viewpoints for the Scope section of the <a href="http://w3c.github.io/wot/charters/smart-cities/smart-cities-ig-charter.html">draft Smart Cities Interest Group Charter</a>, including data governance, smart cities in developing countries, and a survey of existing smart cities.</li>
+    <li>We also identified important additional SDOs, Government agencies, Smart City projects and communities to liaise with and potential liaison contacts from those organizations as the workshop speakers, including Josh Lieberman (OGC), Heng Qian (ISO/IEC JTC1), Peter Lee (BSI), Jerome Blum (ECLASS), Sisay Chala (GOEASY), Jacqueline Lu (DTPR), Dave McComb (semantic arts), and Clarissa Loureiro (Clarissa Loureiro).</li>
+    <li>We will finalize the <a href="http://w3c.github.io/wot/charters/smart-cities/smart-cities-ig-charter.html">draft Smart Cities Interest Group Charter</a> based on the feedback from the workshop, and launch the group to start further discussion on the use cases and requirements for Smart Cities as well as doing a survey of existing technologies and standards for Smart Cities.</li>
 </ul>
 </section>
 </section>


### PR DESCRIPTION
- Small wording changes mostly, trying to simplify the text and normalize the English and punctuation.  Avoided use of & (use "and"), replaced "e.g." with "including", adding "and" before last elements of lists, added periods consistently after list elements that were meant to be separate sentences, etc.
- The paragraph on inclusion was written in such a way that emphasized the negative aspects of Smart Cities technologies, and almost made it seem like people were an afterthought, which is totally not the point.   I rewrote it to emphasize that the goal was to positively impact people lives, but that we wanted to avoid *unintended* negative consequences.  The paragraph was also one big run-on sentence so I broke it up.

The opening paragraph is also a single very long sentence.  Although I did not do so in this PR, I would like to suggest rewriting it into a sequence of shorter, simpler sentences.